### PR TITLE
Ready for ESP32 V3 &V2

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -186,7 +186,15 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
     return;
   }
   if(_messageQueue.length() >= SSE_MAX_QUEUED_MESSAGES){
-      ets_printf("ERROR: Too many messages queued\n");
+     #ifdef ESP_ARDUINO_VERSION_MAJOR
+        #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+                     // Code for version 3.x
+          log_e("ERROR: Too many messages queued\n");
+        #else
+                    // Code for version 2.x
+	      ets_printf("ERROR: Too many messages queued\n");
+        #endif
+      #endif	  
       delete dataMessage;
   } else {
       _messageQueue.add(dataMessage);

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -546,7 +546,15 @@ void AsyncWebSocketClient::_queueMessage(AsyncWebSocketMessage *dataMessage){
     return;
   }
   if(_messageQueue.length() >= WS_MAX_QUEUED_MESSAGES){
-      ets_printf("ERROR: Too many messages queued\n");
+     #ifdef ESP_ARDUINO_VERSION_MAJOR
+        #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+                     // Code for version 3.x
+          log_e("ERROR: Too many messages queued\n");
+        #else
+                    // Code for version 2.x
+	      ets_printf("ERROR: Too many messages queued\n");
+        #endif
+      #endif	
       delete dataMessage;
   } else {
       _messageQueue.add(dataMessage);

--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -69,16 +69,28 @@ static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or mo
   if(_buf == NULL)
     return false;
   memset(_buf, 0x00, 16);
-#ifdef ESP32
-  mbedtls_md5_init(&_ctx);
-  mbedtls_md5_starts_ret(&_ctx);
-  mbedtls_md5_update_ret(&_ctx, data, len);
-  mbedtls_md5_finish_ret(&_ctx, _buf);
-#else
-  MD5Init(&_ctx);
-  MD5Update(&_ctx, data, len);
-  MD5Final(_buf, &_ctx);
-#endif
+  #ifdef ESP_ARDUINO_VERSION_MAJOR
+     #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+      // Code for version 3.x
+     mbedtls_md5_init(&_ctx);
+     mbedtls_md5_starts(&_ctx);
+     mbedtls_md5_update(&_ctx, data, len);
+     mbedtls_md5_finish(&_ctx, _buf);
+     #else
+      // Code for version 2.x
+     #ifdef ESP32
+        mbedtls_md5_init(&_ctx);
+        mbedtls_md5_starts_ret(&_ctx);
+        mbedtls_md5_update_ret(&_ctx, data, len);
+        mbedtls_md5_finish_ret(&_ctx, _buf);
+     #else
+        MD5Init(&_ctx);
+        MD5Update(&_ctx, data, len);
+        MD5Final(_buf, &_ctx);
+      #endif
+  #endif
+  #endif
+
   for(i = 0; i < 16; i++) {
     sprintf(output + (i * 2), "%02x", _buf[i]);
   }


### PR DESCRIPTION
 Changed ESP32 board to 3.0.0
               Changed in Arduino\libraries\ESPAsyncWebServer\src\WebAuthentic
               at line 75,76,77   
               //-----------------              
                #ifdef ESP_ARDUINO_VERSION_MAJOR
                   #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
                     // Code for version 3.x
                   mbedtls_md5_init(&_ctx);
                   mbedtls_md5_starts(&_ctx);
                   mbedtls_md5_update(&_ctx, data, len);
                   mbedtls_md5_finish(&_ctx, _buf);
                   #else
                    // Code for version 2.x
                   #ifdef ESP32
                      mbedtls_md5_init(&_ctx);
                      mbedtls_md5_starts_ret(&_ctx);
                      mbedtls_md5_update_ret(&_ctx, data, len);
                      mbedtls_md5_finish_ret(&_ctx, _buf);
                   #else
                      MD5Init(&_ctx);
                      MD5Update(&_ctx, data, len);
                      MD5Final(_buf, &_ctx);
                    #endif
                 #endif
                #endif
               //-------------------- 
               in AsyncEventSource.cpp changed at line 189 ets_printf --> log_e for V3
               in AsyncWebSocket.cpp changed at line 549 ets_printf --> log_e  for V3
                 #ifdef ESP_ARDUINO_VERSION_MAJOR
                   #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
                     // Code for version 3.x
                    log_e("ERROR: Too many messages queued\n");
                   #else
                    // Code for version 2.x
                    ets_printf("ERROR: Too many messages queued\n");
                 #endif
                #endif